### PR TITLE
Fix/cylindrical hole mesh size

### DIFF
--- a/Examples/Cylindrical_hole_test/Cylindrical_hole_test.ipynb
+++ b/Examples/Cylindrical_hole_test/Cylindrical_hole_test.ipynb
@@ -51,7 +51,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": 1,
       "metadata": {
         "id": "43TV67647-LF"
       },
@@ -83,7 +83,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": 2,
       "metadata": {
         "id": "EQ4mWUN37-8m"
       },
@@ -163,8 +163,8 @@
         "gmsh.model.setPhysicalName(2, 2, \"rectangle area\")\n",
         "\n",
         "# Generating Mesh\n",
-        "gmsh.option.setNumber(\"Mesh.CharacteristicLengthMin\",h)\n",
-        "gmsh.option.setNumber(\"Mesh.CharacteristicLengthMax\",h)\n",
+        "gmsh.option.setNumber(\"Mesh.CharacteristicLengthMin\",16*h)\n",
+        "gmsh.option.setNumber(\"Mesh.CharacteristicLengthMax\",16*h)\n",
         "gmsh.model.mesh.generate(2)\n",
         "gmsh.model.mesh.setOrder(1)\n",
         "\n",
@@ -245,7 +245,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": 4,
       "metadata": {
         "id": "acafQAysCgLN"
       },
@@ -267,7 +267,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": 5,
       "metadata": {
         "id": "dqNyDfcPCjRI"
       },
@@ -332,7 +332,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": 6,
       "metadata": {
         "id": "dv-Kzm7tD6lH"
       },
@@ -376,7 +376,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
+      "execution_count": 7,
       "metadata": {
         "id": "MI_ZS1LSD8rw"
       },
@@ -409,7 +409,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
+      "execution_count": 8,
       "metadata": {
         "id": "YGJeWK6ND9hN"
       },
@@ -472,7 +472,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
+      "execution_count": 9,
       "metadata": {
         "id": "-ww5tqN1EBIE"
       },
@@ -516,7 +516,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 18,
+      "execution_count": 10,
       "metadata": {
         "id": "lHAVrmDBECG1"
       },
@@ -542,7 +542,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 19,
+      "execution_count": 11,
       "metadata": {
         "id": "ygT_uijkED59"
       },
@@ -569,7 +569,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 21,
+      "execution_count": 12,
       "metadata": {
         "id": "C9COYX9AEFdU"
       },
@@ -624,7 +624,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 22,
+      "execution_count": 13,
       "metadata": {
         "id": "Cv7h_4FNEIGm"
       },
@@ -651,7 +651,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 23,
+      "execution_count": 14,
       "metadata": {
         "id": "D1ibRqgNELOs"
       },

--- a/Examples/Cylindrical_hole_test/Cylindrical_hole_test.ipynb
+++ b/Examples/Cylindrical_hole_test/Cylindrical_hole_test.ipynb
@@ -267,7 +267,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": null,
       "metadata": {
         "id": "dqNyDfcPCjRI"
       },
@@ -288,7 +288,9 @@
         "    return (x[1]<1e-4) & (x[0]>Rad - 1e-4)\n",
         "\n",
         "def cracktip(x):\n",
-        "    return (x[1] < 1e-4) & (x[0] > Rad - h*8*2) & (x[0] < Rad+1e-4)\n",
+        "    ac = 0.     # The current set up is without any sharp crack.\n",
+        "                # You can add a sharp crack by setting ac to a positive value. The length of the sharp crack will be ac.\n",
+        "    return (x[1] < 1e-4) & (x[0] > Rad - h*8*2) & (x[0] < Rad+1e-4+ac)\n",
         "\n",
         "def outer(x):\n",
         "    return (x[1] > L/10)\n",


### PR DESCRIPTION
# Summary
Fixes mesh-size handling in the cylindrical-hole example so $\delta$ calibration is consistent with adaptive refinement.

## What changed
- Corrected Gmsh characteristic length setup to match the intended post-refinement size.
- Updated $\delta$ handling/documentation to align with the actual mesh-size assumption used in the example.
- Add some comments on the phase-field BCs.

Fixes #1 and #2